### PR TITLE
Provide auth token to npm

### DIFF
--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -2,6 +2,8 @@
 # It also produces build artifacts that can be published at a later stage.
 #
 # It is triggered by other workflows as needed.
+# It is also triggered by pushing commits to the `main` branch to prepare the workflow cache for future pull requests.
+# https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
 #
 # It can be triggered manually on any branch via the GitHub CLI:
 #   gh workflow run integrity.yml [--ref <branch-name>]
@@ -13,6 +15,9 @@
 name: Integrity
 
 on:
+  push:
+    branches:
+      - main
   workflow_call:
   workflow_dispatch:
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/
+save-prefix=


### PR DESCRIPTION
This is normally accomplished by `actions/setup-node` in GitHub Actions;
however, we are installing Node.js and pnpm via mise-en-place and must
provide the token manually.